### PR TITLE
 "css-unused-selector" warning

### DIFF
--- a/src/components/HookDetail/HookDetail.svelte
+++ b/src/components/HookDetail/HookDetail.svelte
@@ -80,17 +80,8 @@
     font-size: 14px;
   }
 
-  .hook p {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
-
   .overview {
     margin-right: 1rem;
-  }
-
-  h3 {
-    margin-top: 0;
   }
 
   @media (min-width: 768px) {
@@ -113,13 +104,6 @@
     margin-bottom: 0.75rem;
     padding-bottom: 0.75rem;
     border-bottom: 1px solid #ddd;
-  }
-
-  .hover {
-    position: absolute;
-    background: #fcfcfc;
-    padding: 0.25rem;
-    width: 250px;
   }
 </style>
 


### PR DESCRIPTION
With the current options, svelte gives a "css-unused-selector" warning.
If you want to describe a css that you don't use, consider this area.
[https://github.com/sveltejs/svelte-loader/issues/67](https://github.com/sveltejs/svelte-loader/issues/67)

This is a great OSS!