### PR TITLE
Make assets location portable

### DIFF
--- a/src/layouts/Layout.svelte
+++ b/src/layouts/Layout.svelte
@@ -1,5 +1,6 @@
 <script>
   export let routeHTML, settings;
+  var assets_dir = settings.locations.assets.replace(settings.locations.public, '/');
 </script>
 
 <style>
@@ -19,7 +20,7 @@
 </style>
 
 <svelte:head>
-  <link rel="stylesheet" href="{settings.locations.assets.replace('./public', '')}style.css" />
+  <link rel="stylesheet" href="{assets_dir}style.css" />
   <link rel="stylesheet" href="https://unpkg.com/balloon-css/balloon.min.css" />
 </svelte:head>
 <div class="container">


### PR DESCRIPTION
One of the first things I did when starting with this template is to move the **public** folder, however that broke because it's hard-coded in **Layout.svelte**.

This patch means the URL path to the **assets** folder is always computed as the relative path from **public** to **assets**. This is more correct than before but honestly seems a little fragile – if it's always assumed the assets are under the public folder (i.e. not in a CDN), then shouldn't the **assets** path be relative to the **public root**, like this:

```
  locations: {
    public: './public/',
    assets: '/static',
```