### PR TITLE
Typo in path to assets copy target in copyAssetsToPublic hook

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -50,10 +50,10 @@ const hooks = [
         const parsed = path.parse(file);
         // Only write the file/folder structure if it has an extension
         if (parsed.ext && parsed.ext.length > 0) {
-          const relativeToAssetsFolder = path.relative(path.join(settings.rootDir, './src/assets'), file)
-          const outputPath = path.resolve(settings.distDir, relativeToAssetsFolder)
-          fs.ensureDirSync(path.parse(outputPath).dir)
-          fs.outputFileSync(outputPath, fs.readFileSync(file))
+          const relativeToAssetsFolder = path.relative(path.join(settings.rootDir, './assets'), file);
+          const outputPath = path.resolve(settings.distDir, relativeToAssetsFolder);
+          fs.ensureDirSync(path.parse(outputPath).dir);
+          fs.outputFileSync(outputPath, fs.readFileSync(file));
         }
       });
     },


### PR DESCRIPTION
Hi Nick, team, & friends,

Tiny fix — looks like when the folder structure was updated in the bump up to v1, the public destination of the assets folder in the `copyAssetsToPublic` hook didn't update.

Nice talk today Nick! 👍 

