### PR TITLE
chore: remove deprecated lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,13 @@
     "fs-extra": "^9.0.1",
     "glob": "^7.1.6",
     "gray-matter": "^4.0.2",
-    "markdown-js": "^0.0.4",
+    "intersection-observer": "^0.11.0",
     "polka": "^0.5.2",
     "remark": "^12.0.1",
     "remark-html": "^12.0.0",
     "sirv": "^1.0.5",
     "svelte": "^3.24.0",
     "svelte-preprocess": "^4.0.9",
-    "intersection-observer": "^0.11.0",
     "systemjs": "^6.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
[Markdown-js](https://www.npmjs.com/package/markdown-js) is flagged as deprecated on npmjs.com.

Removes the dependency entirely from the template. 🤔 Running `npm run build` and the project compiled
without complaint. So it also appears that this dep was not being used.