### PR TITLE
chore: removes unused component

### DIFF
--- a/src/routes/hooks/Hooks.svelte
+++ b/src/routes/hooks/Hooks.svelte
@@ -1,6 +1,5 @@
 <script>
   import HookDetail from '../../components/HookDetail.svelte';
-  import Blog from '../blog/Blog.svelte';
 
   export let data;
 </script>


### PR DESCRIPTION
This component is not being used within this file. A small bit
of friction when getting started with the template. Removing
the /blog directory causes the server to stop working as it can
no longer resolve the Blog.svelte component.