### PR TITLE
fix: more robust clean of dist dir

### DIFF
--- a/src/cleanPublic.js
+++ b/src/cleanPublic.js
@@ -1,10 +1,11 @@
+const path = require('path');
 const del = require('del');
 const { getConfig } = require('@elderjs/elderjs');
 
 const { distDir } = getConfig();
 
 console.log(' Clearing out public folder.');
-del.sync(`${distDir}*`);
+del.sync(path.join(distDir, '*'));
 
 // this file is optional, but is included in the template
 // to prevent inconsistencies and hard to debug problems.


### PR DESCRIPTION
Hi! The `cleanPublic.js` script was not working for me out of the box because it was trying to delete "public*". These changes make it more robust: it will work regardless of any trailing '/' in configured dist dir...