### PR TITLE
feat: 🎸 Use server.origin on build output

### DIFF
--- a/src/layouts/Layout.svelte
+++ b/src/layouts/Layout.svelte
@@ -19,7 +19,7 @@
 </style>
 
 <svelte:head>
-  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href={`${settings['$$internal'].serverPrefix}/style.css`} />
   <link rel="stylesheet" href="https://unpkg.com/balloon-css/balloon.min.css" />
 </svelte:head>
 <div class="container">

--- a/src/routes/blog/Blog.svelte
+++ b/src/routes/blog/Blog.svelte
@@ -1,5 +1,5 @@
 <script>
-  export let data; // data is mainly being populated from the /plugins/edlerjs-plugin-markdown/index.js
+  export let data, settings; // data is mainly being populated from the /plugins/edlerjs-plugin-markdown/index.js
   const { html, frontmatter } = data;
 </script>
 
@@ -49,7 +49,7 @@
 <svelte:head>
   <title>{frontmatter.title}</title>
 </svelte:head>
-<a href="/">&LeftArrow; Home</a>
+<a href={settings['$$internal'].serverPrefix}>&LeftArrow; Home</a>
 
 <div class="title">
   <h1>{frontmatter.title}</h1>

--- a/src/routes/hooks/Hooks.svelte
+++ b/src/routes/hooks/Hooks.svelte
@@ -1,7 +1,7 @@
 <script>
   import HookDetail from '../../components/HookDetail.svelte';
 
-  export let data;
+  export let data, settings;
 </script>
 
 <style>
@@ -15,7 +15,7 @@
   <title>{data.hook} Hook Interface: Elder.js Example Project</title>
 </svelte:head>
 
-<a href="/">&LeftArrow; Home</a>
+<a href={settings['$$internal'].serverPrefix}>&LeftArrow; Home</a>
 
 <HookDetail {...data} />
 

--- a/src/routes/simple/Simple.svelte
+++ b/src/routes/simple/Simple.svelte
@@ -1,5 +1,5 @@
 <script>
-  export let data, helpers;
+  export let data, helpers, settings;
 </script>
 
 <style>
@@ -13,7 +13,7 @@
   <title>{data.title}</title>
 </svelte:head>
 
-<a href="/">&LeftArrow; Home</a>
+<a href={settings['$$internal'].serverPrefix}>&LeftArrow; Home</a>
 
 <h1>{data.title}</h1>
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,9 +1,11 @@
 require('dotenv').config();
+const path = require('path')
 const polka = require('polka');
 const cors = require('cors');
 const compression = require('compression');
 const bodyParser = require('body-parser');
 const sirv = require('sirv');
+const elderConfig = require('../elder.config')
 const dev = process.env.NODE_ENV === 'development';
 
 const { Elder } = require('@elderjs/elderjs');
@@ -14,7 +16,7 @@ server.use(cors());
 server.use(compression({ level: 6 }));
 server.use(bodyParser.urlencoded({ extended: false }), bodyParser.json());
 server.use(elder.server);
-server.use(sirv(elder.settings.distDir, { dev }));
+server.use(sirv(path.join(elder.settings.rootDir, elderConfig.distDir), { dev }));
 
 const SERVER_PORT = process.env.SERVER_PORT || 3000;
 server.listen(SERVER_PORT, (err) => {


### PR DESCRIPTION
Requires https://github.com/Elderjs/elderjs/pull/126

This PR updates:
- the return buttons to be the root of the `server.prefix`
- the server root