### PR TITLE
Update template to mention Cloudflare Pages

### DIFF
--- a/src/routes/home/Home.svelte
+++ b/src/routes/home/Home.svelte
@@ -145,7 +145,7 @@
 
   <p>
     <strong>Note:</strong> Make sure you also check out <code>npm run build</code>, which will statically generate this
-    same site so that it can be deployed with a static site host such as Netlify, Cloudflare Workers, Vercel, or S3.
+    same site so that it can be deployed with a static site host such as Netlify, Cloudflare Pages, Vercel, or S3.
   </p>
 </div>
 


### PR DESCRIPTION
Cloudflare Pages (https://pages.dev) is our Jamstack-y static site deployment tool - since it's been released, it's a better fit to mention here than Workers!