### PR TITLE
remove redundant code in clock hydration

### DIFF
--- a/src/routes/home/Home.svelte
+++ b/src/routes/home/Home.svelte
@@ -191,7 +191,7 @@
     </p>
   </div>
   <div class="right">
-    <Clock hydrate-client={{ willThisBreak: '""}{))((èé', p }} />
+    <Clock hydrate-client={{}} />
   </div>
 </div>
 


### PR DESCRIPTION
There was some code leftover in the Clock component that would cause `npm run start` to fail.