### PR TITLE
Copy *all* assets files

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -47,14 +47,10 @@ const hooks = [
 
       // copy assets folder to public destination
       glob.sync(path.resolve(settings.rootDir, './assets/**/*')).forEach((file) => {
-        const parsed = path.parse(file);
-        // Only write the file/folder structure if it has an extension
-        if (parsed.ext && parsed.ext.length > 0) {
-          const relativeToAssetsFolder = path.relative(path.join(settings.rootDir, './assets'), file);
-          const outputPath = path.resolve(settings.distDir, relativeToAssetsFolder);
-          fs.ensureDirSync(path.parse(outputPath).dir);
-          fs.outputFileSync(outputPath, fs.readFileSync(file));
-        }
+        const relativeToAssetsFolder = path.relative(path.join(settings.rootDir, './assets'), file);
+        const outputPath = path.resolve(settings.distDir, relativeToAssetsFolder);
+        fs.ensureDirSync(path.parse(outputPath).dir);
+        fs.outputFileSync(outputPath, fs.readFileSync(file));
       });
     },
   },

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -4,19 +4,19 @@ const fs = require('fs-extra');
 const os = require('os');
 
 /**
- * Hooks! 
- * 
+ * Hooks!
+ *
  * Lifecycle hooks are the backbone of how you can have complete control over the output of your site.
- * Hooks are enforced via the hookInterface 'contract' defined here: 
+ * Hooks are enforced via the hookInterface 'contract' defined here:
         https://github.com/Elderjs/elderjs/blob/master/src/hookInterface/hookInterface.ts
  *
  * If you read the hookInterface spec closely you'll see that each defined hook gets specific 'props' along with which of those props is 'mutable'.
- * 
- * If you're a fan of 'pure' functions in JS, mutating props will probably set off alarm bells in your head. Fear not, instead of burying 
+ *
+ * If you're a fan of 'pure' functions in JS, mutating props will probably set off alarm bells in your head. Fear not, instead of burying
  * what is mutating things deep in your application, you'll know it is probably in this file.
  *
- * Also, to help keep mutation predictable each 'hook' limits which 'props' can be manipulated and where. 
- * 
+ * Also, to help keep mutation predictable each 'hook' limits which 'props' can be manipulated and where.
+ *
  */
 
 const hooks = [


### PR DESCRIPTION
Currently the hook to copy the assets folder into public will ignore files without an extension. This is confusing, and many "meta" files that you **do** want copied to public are silently excluded by this.

This change removes that restriction.

Here is the meat of the change: c23be2771861bb2a305825b35590da04cba8d5be

I couldn't figure out how to make VS Code **not** trim trailing spaces, so I did that as a separate commit.